### PR TITLE
test scenario for low engine fps

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -23,31 +23,31 @@ window/size/always_on_top=true
 
 move_left={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":13,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 move_right={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":14,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 jump={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
 toggle_max_fps={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194329,"key_label":0,"unicode":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194329,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 
@@ -57,3 +57,7 @@ toggle_max_fps={
 2d_physics/layer_2="enemies"
 2d_physics/layer_3="items"
 2d_physics/layer_4="world"
+
+[physics]
+
+common/physics_ticks_per_second=13

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="godot-smoother-test"
 run/main_scene="res://src/Levels/level2d.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.svg"
 
 [display]
@@ -45,6 +45,11 @@ jump={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
 ]
 }
+toggle_max_fps={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194329,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 
@@ -52,7 +57,3 @@ jump={
 2d_physics/layer_2="enemies"
 2d_physics/layer_3="items"
 2d_physics/layer_4="world"
-
-[physics]
-
-common/physics_ticks_per_second=13

--- a/src/Classes/smoother.gd
+++ b/src/Classes/smoother.gd
@@ -26,6 +26,19 @@ class_name Smoother extends Node
 ## A node type that smoothes scene nodes' properties by interpolating _physics_process steps.
 ##
 ## For documentation please visit https://github.com/anatolbogun/godot-smoother-node .
+##
+## ----------------------------------------> IMPORTANT NOTE <----------------------------------------
+## Since Godot 4.3 Beta 1 you can find built-in physics interpolation for 2D in
+## Project settings > Physics > Common > Physics Interpolation.
+## Physics interpolation for 3D is being worked on and should make it into a future release.
+## See https://godotengine.org/article/dev-snapshot-godot-4-3-beta-1/#2d-physics-interpolation .
+## If you can use a Godot version with built-in physics interpolation, I highly recommend to use that
+## and disable or delete this Smoother node from your project. This node was ever only intended as an
+## interim solution until this is added natively to the engine. The built-in physics interpolation
+## also has better support for all node types such as RigidBody2D (which this node cannot handle).
+## Once native physics interpolation moves into stable builds, this Node will be deprecated, unless
+## any pre-native-interpolation Godot 4 versions absolutely need an important fix.
+## --------------------------------------------------------------------------------------------------
 
 ## Node properties that are interpolated.
 ## Defaults to ["position"], even if not displayed in the inspector.

--- a/src/Classes/smoother.gd
+++ b/src/Classes/smoother.gd
@@ -21,7 +21,7 @@
 class_name Smoother extends Node
 
 ## Smoother Node
-## Version: 1.0.4
+## Version: 1.0.5
 ##
 ## A node type that smoothes scene nodes' properties by interpolating _physics_process steps.
 ##

--- a/src/Classes/smoother.gd
+++ b/src/Classes/smoother.gd
@@ -60,6 +60,7 @@ var smoothed_nodes:Array[Node] :
 var _properties: = {}
 var _physics_process_nodes:Array[Node]
 var _physics_process_just_updated: = false
+var _apply: = true
 
 
 ## Reset all smoothed nodes.
@@ -148,7 +149,10 @@ func _process(_delta: float) -> void:
 				if _physics_process_just_updated:
 					values[1] = node[property]
 
-				node[property] = lerp(values[0], values[1], Engine.get_physics_interpolation_fraction())
+				if _apply:
+					node[property] = lerp(values[0], values[1], Engine.get_physics_interpolation_fraction())
+				else:
+					node[property] = values[1]
 
 	_physics_process_just_updated = false
 
@@ -157,14 +161,7 @@ func _process(_delta: float) -> void:
 ## _physics_process frames for interpolation in the upcoming _process frames and apply the origin
 ## values.
 func _physics_process(_delta: float) -> void:
-	if (Engine.max_fps < Engine.physics_ticks_per_second
-		|| (
-			Engine.max_fps == 0
-			&& DisplayServer.screen_get_refresh_rate() < Engine.physics_ticks_per_second
-		)
-	):
-		reset()
-		return
+	_apply = Engine.get_frames_per_second() > Engine.physics_ticks_per_second
 
 	var parent: = get_parent()
 	if parent == null: return
@@ -204,7 +201,8 @@ func _physics_process(_delta: float) -> void:
 				_properties[node][property][1] = node[property]
 			else:
 				_properties[node][property][0] = _properties[node][property][1]
-				node[property] = _properties[node][property][0]
+				if _apply:
+					node[property] = _properties[node][property][0]
 
 	_physics_process_just_updated = true
 

--- a/src/Classes/smoother.gd
+++ b/src/Classes/smoother.gd
@@ -157,6 +157,15 @@ func _process(_delta: float) -> void:
 ## _physics_process frames for interpolation in the upcoming _process frames and apply the origin
 ## values.
 func _physics_process(_delta: float) -> void:
+	if (Engine.max_fps < Engine.physics_ticks_per_second
+		|| (
+			Engine.max_fps == 0
+			&& DisplayServer.screen_get_refresh_rate() < Engine.physics_ticks_per_second
+		)
+	):
+		reset()
+		return
+
 	var parent: = get_parent()
 	if parent == null: return
 

--- a/src/Levels/level2d.gd
+++ b/src/Levels/level2d.gd
@@ -10,6 +10,12 @@ func _ready() -> void:
 		cameraNode.limit_right = $TileMap.get_used_rect().end.x * $TileMap.tile_set.tile_size.x
 
 
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("toggle_max_fps"):
+		Engine.max_fps = 10 if Engine.max_fps == 0 else 0
+		print('Engine.max_fps: ', Engine.max_fps)
+
+
 func _on_node_teleport_started(node: Node) -> void:
 	print("teleporting: ", node.name)
 

--- a/src/Levels/level2d.tscn
+++ b/src/Levels/level2d.tscn
@@ -13,22 +13,14 @@
 texture = ExtResource("4_p0vq3")
 texture_region_size = Vector2i(80, 80)
 0:1/0 = 0
-0:1/0/physics_layer_0/linear_velocity = Vector2(0, 0)
-0:1/0/physics_layer_0/angular_velocity = 0.0
 0:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-40, 40, 40, -40, 40, 40)
 0:0/0 = 0
-0:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
-0:0/0/physics_layer_0/angular_velocity = 0.0
 0:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(40, -40, 40, -40, 40, 40, -40, 40, -40, -40)
 0:2/size_in_atlas = Vector2i(2, 1)
 0:2/0 = 0
 0:2/0/texture_origin = Vector2i(-40, 0)
-0:2/0/physics_layer_0/linear_velocity = Vector2(0, 0)
-0:2/0/physics_layer_0/angular_velocity = 0.0
 0:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-40, 40, 119.5, -39, 120, 40.5)
 1:0/0 = 0
-1:0/0/physics_layer_0/linear_velocity = Vector2(0, 0)
-1:0/0/physics_layer_0/angular_velocity = 0.0
 
 [sub_resource type="TileSet" id="TileSet_mjviy"]
 tile_size = Vector2i(80, 80)
@@ -43,6 +35,7 @@ camera = NodePath("Player/Camera2D")
 [node name="Smoother" type="Node" parent="."]
 script = ExtResource("2_lr87i")
 properties = Array[String](["position", "rotation"])
+excludes = Array[NodePath]([NodePath("../Player2")])
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = -1
@@ -78,6 +71,11 @@ drag_vertical_enabled = true
 drag_left_margin = 0.0
 drag_right_margin = 0.0
 
+[node name="Player2" parent="." instance=ExtResource("6_6wubv")]
+modulate = Color(1, 0.0980392, 0, 1)
+position = Vector2(261, 148)
+safe_margin = 3.0
+
 [node name="RigidBody" parent="." instance=ExtResource("7_bgcgm")]
 position = Vector2(2720, 12)
 collision_mask = 15
@@ -94,6 +92,7 @@ position = Vector2(2220, 556)
 position = Vector2(3056, 556)
 
 [connection signal="teleport_started" from="Player" to="." method="_on_node_teleport_started"]
+[connection signal="teleport_started" from="Player2" to="." method="_on_node_teleport_started"]
 [connection signal="screen_entered" from="NestedTest/Enemy1" to="." method="_on_node_screen_entered"]
 [connection signal="screen_exited" from="NestedTest/Enemy1" to="." method="_on_node_screen_exited"]
 [connection signal="screen_entered" from="NestedTest/Enemy2" to="." method="_on_node_screen_entered"]


### PR DESCRIPTION
This implements the fix from @elvisish 's comment in [this issue](https://github.com/anatolbogun/godot-smoother-node/issues/2#issuecomment-1860730870).

For testing purposes I added a way to toggle `Engine.max_fps` between `0` (unlimited) and `10`. To toggle, press CapsLock in the sample project. The new `max_fps` will be printed in the output window.

I'm really sorry that I've been so unresponsive. I didn't find any time for months to focus on Godot, and looking at it now almost feels like starting from scratch reading someone else's code 😬 …

If some people could give this a try and use the [smoother.gd code from this branch](https://github.com/anatolbogun/godot-smoother-node-test-scene/blob/cc4c878f1eda2d9066fa362469eacf9559e41b1c/src/Classes/smoother.gd), that'd be much appreciated. Especially in projects where you experienced the issue.